### PR TITLE
通过jacoco+coveralls记录测试覆盖率

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,11 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.eluder.coveralls</groupId>
+                    <artifactId>coveralls-maven-plugin</artifactId>
+                    <version>4.3.0</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -182,16 +182,16 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.4</version>
+                    <version>0.8.5</version>
                     <executions>
                         <execution>
+                            <id>prepare-agent</id>
                             <goals>
                                 <goal>prepare-agent</goal>
                             </goals>
                         </execution>
                         <execution>
                             <id>report</id>
-                            <phase>prepare-package</phase>
                             <goals>
                                 <goal>report</goal>
                             </goals>
@@ -224,6 +224,10 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.eluder.coveralls</groupId>
+                <artifactId>coveralls-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <powermock.version>2.0.7</powermock.version>
 
         <graphql-java.version>14.0</graphql-java.version>
-        <graphql-java-extended-scalars.version>1.1.0</graphql-java-extended-scalars.version>
+        <graphql-java-extended-scalars.version>1.0.1</graphql-java-extended-scalars.version>
         <kickstart.version>7.0.1</kickstart.version>
 
         <dgraph4j.version>20.03.0</dgraph4j.version>


### PR DESCRIPTION
1. fix graphql-java-extended version to 1.0.1 维护方未按照版本发布至maven repository ，1.0.1版本满足使用需求 https://github.com/graphql-java/graphql-java-extended-scalars/issues/24
2. 升级jacoco版本并引入coveralls插件，配合CICD上报测试覆盖率 CI通过 [Github Actions](https://docs.github.com/en/actions/configuring-and-managing-workflows)


resolve #1 