### PR TITLE
Setup version on releasing

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -21,7 +21,11 @@ jobs:
         java-version: 1.8
         server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
         settings-path: ${{ github.workspace }} # location for the settings.xml file
-    
+
+    - name: Setup version
+      run: mvn versions:set -DnewVersion=$(basename $GITHUB_REF)
+      if: ${{ github.event == 'release' }}
+
     - name: Test
       run: mvn clean jacoco:prepare-agent test -B jacoco:report-aggregate jacoco:report -DfailIfNoTests=false
 
@@ -36,11 +40,12 @@ jobs:
         SONAR_ORGANIZATION: ${{secrets.SONAR_ORGANIZATION}}
         SONAR_PROJECT_KEY: ${{secrets.SONAR_PROJECT_KEY}}
         SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}  
-        
+                
     - name: Build with Maven
       run: mvn -B package --file pom.xml
 
     - name: Publish to GitHub Packages Apache Maven
       run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+      if: ${{ github.event == 'release' }}
       env:
         GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
这样做的目的是为了发布包的时候其版本号与 Release 保持一致.