### PR TITLE
Bugfix/windows newline

### DIFF
--- a/generator/src/main/java/ai/care/arc/generator/codegen/DictionaryGenerator.java
+++ b/generator/src/main/java/ai/care/arc/generator/codegen/DictionaryGenerator.java
@@ -4,13 +4,11 @@ import ai.care.arc.generator.codegen.util.JavadocUtils;
 import ai.care.arc.generator.codegen.util.PackageManager;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.TypeSpec;
-import graphql.language.Description;
 import graphql.language.EnumTypeDefinition;
 import graphql.schema.idl.TypeDefinitionRegistry;
 import org.springframework.util.StringUtils;
 
 import javax.lang.model.element.Modifier;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
 

--- a/generator/src/main/java/ai/care/arc/generator/codegen/DictionaryGenerator.java
+++ b/generator/src/main/java/ai/care/arc/generator/codegen/DictionaryGenerator.java
@@ -44,7 +44,7 @@ public class DictionaryGenerator implements IGenerator {
             enumTypeDefinition.getEnumValueDefinitions()
                     .forEach(enumValueDefinition ->
                             typeSpecBuilder.addEnumConstant(enumValueDefinition.getName(), TypeSpec.anonymousClassBuilder("")
-                                    .addJavadoc(Optional.ofNullable(enumValueDefinition.getDescription()).map(Description::getContent).orElse(enumValueDefinition.getName()))
+                                    .addJavadoc(JavadocUtils.getFieldDocByDescription(enumValueDefinition.getDescription(), enumValueDefinition.getName()))
                                     .build()));
             return typeSpecBuilder;
         }

--- a/generator/src/main/java/ai/care/arc/generator/codegen/util/JavadocUtils.java
+++ b/generator/src/main/java/ai/care/arc/generator/codegen/util/JavadocUtils.java
@@ -49,7 +49,7 @@ public interface JavadocUtils {
      */
     static CodeBlock getFieldDocByDescription(Description description, String defaultContent) {
         return CodeBlock.builder()
-                .add(Optional.ofNullable(description).map(Description::getContent).orElse(defaultContent))
+                .add(Optional.ofNullable(description).map(Description::getContent).map(String::trim).orElse(defaultContent))
                 .build();
     }
 
@@ -61,9 +61,10 @@ public interface JavadocUtils {
      */
     static CodeBlock getClassDocByDescription(Description description, String defaultContent) {
         return CodeBlock.builder()
-                .add(Optional.ofNullable(description).map(Description::getContent).orElse(defaultContent))
+                .add(Optional.ofNullable(description).map(Description::getContent).map(String::trim).orElse(defaultContent))
                 .add("\n")
                 .add(GeneratorGlobalConst.GENERAL_CODE_BLOCK)
                 .build();
     }
+
 }


### PR DESCRIPTION
resolve #31 

通过trim移除windows系统读取schema注释文本时头尾的换行符(`\r\n`)