### PR TITLE
bugfix: 项目中使用@EnableFeignClients后Graphql方法注册失败，无法调用

### DIFF
--- a/graphql/src/main/java/ai/care/arc/graphql/GraphQLProvider.java
+++ b/graphql/src/main/java/ai/care/arc/graphql/GraphQLProvider.java
@@ -12,13 +12,17 @@ import graphql.schema.idl.TypeDefinitionRegistry;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.ApplicationListener;
-import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.core.io.ClassPathResource;
 
 import java.io.IOException;
 
-public class GraphQLProvider implements ApplicationListener<ContextRefreshedEvent> {
+/**
+ * 解析schema并提供graphql服务
+ *
+ * @author yuheng.wang
+ * @see GraphQL
+ */
+public class GraphQLProvider {
 
     private static final Logger log = org.slf4j.LoggerFactory.getLogger(GraphQLProvider.class);
     @Value("${arc.graphql.define:graphql/schema.graphqls}")
@@ -26,12 +30,6 @@ public class GraphQLProvider implements ApplicationListener<ContextRefreshedEven
     @Autowired(required = false)
     private DataFetcherInterceptorRegistry dataFetcherInterceptorRegistry;
     private GraphQL graphQL;
-
-    @Override
-    public void onApplicationEvent(ContextRefreshedEvent event) {
-        log.info("receive event:{}", event);
-        refresh();
-    }
 
     public GraphQL getGraphQL() {
         if (null == graphQL) {


### PR DESCRIPTION
resolve #27 

## 原因

`feignClient` 在注册过程中 `FeignContext` 会 调用父类`NamedContextFactory`的 `context.refresh();` 方法，并发送事件 `ContextRefreshedEvent`

## 方案

在 `GraphQLProvider` 中忽略 `onApplicationEvent`，通过lazy方式在首次请求时执行初始化

```java
    @Override
    public void onApplicationEvent(ContextRefreshedEvent event) {
        log.info("receive event:{}", event);
        refresh();
    }
```