### PR TITLE
break up drop and create schema

### DIFF
--- a/dgraph/src/main/java/ai/care/arc/dgraph/datasource/DataSourceInitializer.java
+++ b/dgraph/src/main/java/ai/care/arc/dgraph/datasource/DataSourceInitializer.java
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
 
 import java.nio.file.Files;
-import java.util.List;
 
 /**
  * 根据配置初始化Dgraph schema
@@ -30,13 +29,13 @@ public class DataSourceInitializer implements InitializingBean {
     @Override
     public void afterPropertiesSet() throws Exception {
         if (schemaPath.exists()) {
-            List<String> list = Files.readAllLines(schemaPath.getFile().toPath());
-            DgraphProto.Operation operation = DgraphProto.Operation.newBuilder()
-                    .setSchema(String.join("\n", list))
-                    .setDropAll(dropAll)
-                    .build();
-            log.debug("init dgraph by schema:{}", String.join("\n", list));
-            dgraphClient.alter(operation);
+            final String schema = String.join("\n", Files.readAllLines(schemaPath.getFile().toPath()));
+            if (dropAll) {
+                log.debug("drop all data and schema");
+                dgraphClient.alter(DgraphProto.Operation.newBuilder().setDropAll(true).build());
+            }
+            log.debug("init dgraph by schema:{}", schema);
+            dgraphClient.alter(DgraphProto.Operation.newBuilder().setSchema(schema).build());
             log.info("init dgraph by schemaPath:{}, dropAll:{}", schemaPath, dropAll);
         } else {
             log.warn("dgraph schema is not found! path:{} ", schemaPath);

--- a/dgraph/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/dgraph/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -14,7 +14,7 @@
     {
       "name": "arc.dgraph.init",
       "type": "java.lang.Boolean",
-      "description": "init dgraph schema by dgraph define.",
+      "description": "init dgraph schema by dgraph define after drop all.",
       "defaultValue": "false"
     },
     {


### PR DESCRIPTION
close #13 

## 原因 

dgraph4j 提供的alter方法同时执行时，dgraph会先变更表结构，再执行drop-all操作，导致表结构被删除

## 解决方案

拆分为2个事务，先执行drop-all操作，再创建schema

## 其他

[dgraph4j](https://github.com/dgraph-io/dgraph4j/blob/13246633dc87ab884beadf2ac239116890055b48/src/main/proto/api.proto#L92) 提供了更细粒度的drop控制，但是并未提供相关配置。原因

1. drop-all用于初始化配置，不需要细粒度控制
2. 细力度需要指定具体 attr or type值 复杂度不适合初始化+配置的方式 

See [dgraph.io](https://dgraph.io/docs/clients/raw-http/#alter-the-database) for detail