### PR TITLE
增加graphql validation 扩展依赖

### DIFF
--- a/graphql/pom.xml
+++ b/graphql/pom.xml
@@ -42,6 +42,17 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.graphql-java</groupId>
+            <artifactId>graphql-java-extended-validation</artifactId>
+            <version>${graphql-java-extended-validation.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>graphql-java</artifactId>
+                    <groupId>com.graphql-java</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         <!-- to embed playground tool -->
         <dependency>
             <groupId>com.graphql-java-kickstart</groupId>

--- a/graphql/src/main/java/com/github/yituhealthcare/arc/graphql/support/RuntimeWiringRegistry.java
+++ b/graphql/src/main/java/com/github/yituhealthcare/arc/graphql/support/RuntimeWiringRegistry.java
@@ -12,6 +12,9 @@ import graphql.schema.DataFetcher;
 import graphql.schema.idl.RuntimeWiring;
 import graphql.schema.idl.TypeDefinitionRegistry;
 import graphql.schema.idl.TypeRuntimeWiring;
+import graphql.validation.rules.OnValidationErrorStrategy;
+import graphql.validation.rules.ValidationRules;
+import graphql.validation.schemawiring.ValidationSchemaWiring;
 import org.slf4j.Logger;
 import org.springframework.util.CollectionUtils;
 
@@ -73,6 +76,11 @@ public class RuntimeWiringRegistry {
         Stream.of(typeRegistry.getTypes(UnionTypeDefinition.class), typeRegistry.getTypes(InterfaceTypeDefinition.class))
                 .flatMap(Collection::stream)
                 .forEach(RuntimeWiringRegistry.fillBuilder(builder));
+
+        builder.directiveWiring(new ValidationSchemaWiring(ValidationRules.newValidationRules()
+                // will return null for the field input if it is not considered valid
+                .onValidationErrorStrategy(OnValidationErrorStrategy.RETURN_NULL)
+                .build()));
 
         return builder.build();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
 
         <graphql-java.version>14.0</graphql-java.version>
         <graphql-java-extended-scalars.version>1.0.1</graphql-java-extended-scalars.version>
+        <graphql-java-extended-validation.version>14.0.1</graphql-java-extended-validation.version>
         <kickstart.version>7.0.1</kickstart.version>
 
         <dgraph4j.version>20.03.0</dgraph4j.version>

--- a/sample/graphql-sample/src/main/resources/graphql/schema.graphqls
+++ b/sample/graphql-sample/src/main/resources/graphql/schema.graphqls
@@ -1,4 +1,5 @@
 scalar DateTime
+directive @Size(min : Int = 0, max : Int = 20, message : String = "graphql.validation.Size.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
 schema{
     query: Query,
@@ -72,7 +73,7 @@ enum MilestoneStatus{
 }
 
 input ProjectInput{
-    name: String!
+    name: String! @Size(min : 3, max : 100)
     description: String!
     dsl: String!
     vendorBranches: [String!]!


### PR DESCRIPTION
close #67 

通过三方依赖包提供参数扩展能力，并提供使用示例。

详情可以参考 https://github.com/graphql-java/graphql-java-extended-validation