### PR TITLE
提供自定义 directive bean 的方式

### DIFF
--- a/graphql/src/main/java/com/github/yituhealthcare/arc/graphql/GraphqlAutoConfiguration.java
+++ b/graphql/src/main/java/com/github/yituhealthcare/arc/graphql/GraphqlAutoConfiguration.java
@@ -1,22 +1,32 @@
 package com.github.yituhealthcare.arc.graphql;
 
+import brave.http.HttpResponseParser;
 import com.github.yituhealthcare.arc.graphql.interceptor.DataFetcherInterceptorRegistry;
 import com.github.yituhealthcare.arc.graphql.rest.GraphQLController;
+import com.github.yituhealthcare.arc.graphql.support.DirectivePostProcessor;
 import com.github.yituhealthcare.arc.graphql.support.GraphqlPostProcessor;
 import com.github.yituhealthcare.arc.graphql.trace.GraphqlSleuthHttpServerResponseParser;
-import brave.http.HttpResponseParser;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 
+/**
+ * @author wangyuheng
+ */
 @Configuration
 public class GraphqlAutoConfiguration {
 
     @Bean
     @Primary
-    public GraphqlPostProcessor GraphqlPostProcessor() {
+    public GraphqlPostProcessor graphqlPostProcessor() {
         return new GraphqlPostProcessor();
+    }
+
+    @Bean
+    @Primary
+    public DirectivePostProcessor directivePostProcessor() {
+        return new DirectivePostProcessor();
     }
 
     @Bean
@@ -42,4 +52,5 @@ public class GraphqlAutoConfiguration {
     public HttpResponseParser sleuthHttpServerResponseParser() {
         return new GraphqlSleuthHttpServerResponseParser();
     }
+
 }

--- a/graphql/src/main/java/com/github/yituhealthcare/arc/graphql/annotation/Directive.java
+++ b/graphql/src/main/java/com/github/yituhealthcare/arc/graphql/annotation/Directive.java
@@ -1,0 +1,27 @@
+package com.github.yituhealthcare.arc.graphql.annotation;
+
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.*;
+
+/**
+ * 声明Directive类并作为component加入spring生命周期
+ *
+ * @author wangyuheng
+ * @see com.github.yituhealthcare.arc.graphql.support.DirectivePostProcessor
+ */
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Component
+public @interface Directive {
+
+    /**
+     * The name of the directive to wire.
+     * Default is spring bean name.
+     *
+     * @return directive name
+     */
+    String value() default "";
+
+}

--- a/graphql/src/main/java/com/github/yituhealthcare/arc/graphql/rest/GraphQLController.java
+++ b/graphql/src/main/java/com/github/yituhealthcare/arc/graphql/rest/GraphQLController.java
@@ -1,10 +1,10 @@
 package com.github.yituhealthcare.arc.graphql.rest;
 
+import brave.http.HttpResponseParser;
 import com.github.yituhealthcare.arc.graphql.GraphQLProvider;
 import com.github.yituhealthcare.arc.graphql.event.DomainEvent;
 import com.github.yituhealthcare.arc.mq.Message;
 import com.github.yituhealthcare.arc.mq.producer.Producer;
-import brave.http.HttpResponseParser;
 import graphql.ExecutionInput;
 import graphql.ExecutionResult;
 import graphql.GraphQLContext;
@@ -16,9 +16,12 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @RestController
 public class GraphQLController {
@@ -37,7 +40,7 @@ public class GraphQLController {
     private boolean eventEnable;
 
     @PostMapping(value = "${arc.graphql.path:graphql}", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public Object dispatcher(@RequestBody GraphQLRequestBody requestBody, HttpServletResponse response) {
+    public Object dispatcher(@RequestBody GraphQLRequestBody requestBody, HttpServletRequest request, HttpServletResponse response) {
         log.info("graphql receive body:{}", requestBody);
         if ("IntrospectionQuery".equalsIgnoreCase(requestBody.getOperationName())) {
             // schema 查询直接return
@@ -47,7 +50,12 @@ public class GraphQLController {
                 .query(requestBody.getQuery())
                 .operationName(requestBody.getOperationName())
                 .variables(requestBody.getVariables())
-                .context(GraphQLContext.newContext().of("query", requestBody.getQuery()).build())
+                .context(GraphQLContext.newContext()
+                        .of("query", requestBody.getQuery())
+                        .of("headers", Collections.list(request.getHeaderNames())
+                                .stream()
+                                .collect(Collectors.toMap(h -> h, request::getHeader)))
+                        .build())
                 .build();
 
         ExecutionResult executionResult = graphQLProvider.getGraphQL().execute(executionInput);

--- a/graphql/src/main/java/com/github/yituhealthcare/arc/graphql/support/DirectivePostProcessor.java
+++ b/graphql/src/main/java/com/github/yituhealthcare/arc/graphql/support/DirectivePostProcessor.java
@@ -1,0 +1,33 @@
+package com.github.yituhealthcare.arc.graphql.support;
+
+import com.github.yituhealthcare.arc.graphql.annotation.Directive;
+import graphql.schema.idl.SchemaDirectiveWiring;
+import org.springframework.aop.framework.AopProxyUtils;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanInitializationException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+
+/**
+ * 扫描注册Directive类
+ *
+ * @author yuheng.wang
+ * @see Directive
+ * @see RuntimeWiringRegistry
+ */
+public class DirectivePostProcessor implements BeanPostProcessor {
+
+    @Override
+    public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+        Class<?> targetClass = AopProxyUtils.ultimateTargetClass(bean);
+        if (targetClass.isAnnotationPresent(Directive.class)) {
+            Directive directive = targetClass.getAnnotation(Directive.class);
+            if (bean instanceof SchemaDirectiveWiring) {
+                RuntimeWiringRegistry.registerDirective(directive.value(), (SchemaDirectiveWiring) bean);
+            } else {
+                throw new BeanInitializationException("directive bean must implements SchemaDirectiveWiring! bean:" + beanName);
+            }
+        }
+        return bean;
+    }
+
+}

--- a/graphql/src/main/java/com/github/yituhealthcare/arc/graphql/support/RuntimeWiringRegistry.java
+++ b/graphql/src/main/java/com/github/yituhealthcare/arc/graphql/support/RuntimeWiringRegistry.java
@@ -10,6 +10,7 @@ import graphql.language.UnionTypeDefinition;
 import graphql.scalars.ExtendedScalars;
 import graphql.schema.DataFetcher;
 import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaDirectiveWiring;
 import graphql.schema.idl.TypeDefinitionRegistry;
 import graphql.schema.idl.TypeRuntimeWiring;
 import graphql.validation.rules.OnValidationErrorStrategy;
@@ -41,11 +42,16 @@ public class RuntimeWiringRegistry {
     }
 
     private static final Map<String, Map<String, DataFetcher<?>>> TYPE_MAP_FIELD_AND_DF = new ConcurrentHashMap<>();
+    private static final Map<String, SchemaDirectiveWiring> NAME_AND_DIRECTIVE_WIRING = new ConcurrentHashMap<>();
 
     public static void register(String type, String fieldName, DataFetcher<?> dataFetcher) {
         Map<String, DataFetcher<?>> map = TYPE_MAP_FIELD_AND_DF.getOrDefault(type, new ConcurrentHashMap<>());
         map.put(fieldName, dataFetcher);
         TYPE_MAP_FIELD_AND_DF.putIfAbsent(type, map);
+    }
+
+    public static void registerDirective(String name, SchemaDirectiveWiring schemaDirectiveWiring) {
+        NAME_AND_DIRECTIVE_WIRING.putIfAbsent(name, schemaDirectiveWiring);
     }
 
     private static TypeRuntimeWiring.Builder builder(String name, Map<String, DataFetcher<?>> dataFetcherMap, DataFetcherInterceptorRegistry dataFetcherInterceptorRegistry) {
@@ -72,6 +78,7 @@ public class RuntimeWiringRegistry {
                 .scalar(ExtendedScalars.Object)
                 .scalar(ExtendedScalars.Date);
         TYPE_MAP_FIELD_AND_DF.forEach((type, map) -> builder.type(builder(type, map, dataFetcherInterceptorRegistry)));
+        NAME_AND_DIRECTIVE_WIRING.forEach(builder::directive);
 
         Stream.of(typeRegistry.getTypes(UnionTypeDefinition.class), typeRegistry.getTypes(InterfaceTypeDefinition.class))
                 .flatMap(Collection::stream)
@@ -98,4 +105,5 @@ public class RuntimeWiringRegistry {
                     return env.getSchema().getObjectType(domainClassName);
                 }));
     }
+
 }

--- a/graphql/src/test/java/com/github/yituhealthcare/arc/graphql/GraphqlAutoConfigurationTest.java
+++ b/graphql/src/test/java/com/github/yituhealthcare/arc/graphql/GraphqlAutoConfigurationTest.java
@@ -22,7 +22,8 @@ public class GraphqlAutoConfigurationTest {
     @Test
     public void test_context_load() {
         this.contextRunner.run(context -> {
-            assertNotNull(context.getBean("GraphqlPostProcessor"));
+            assertNotNull(context.getBean("graphqlPostProcessor"));
+            assertNotNull(context.getBean("directivePostProcessor"));
             assertNotNull(context.getBean("graphQLController"));
             assertNotNull(context.getBean("dataFetcherInterceptorRegistry"));
         });

--- a/graphql/src/test/java/com/github/yituhealthcare/arc/graphql/support/DirectivePostProcessorTest.java
+++ b/graphql/src/test/java/com/github/yituhealthcare/arc/graphql/support/DirectivePostProcessorTest.java
@@ -1,0 +1,53 @@
+package com.github.yituhealthcare.arc.graphql.support;
+
+import com.github.yituhealthcare.arc.graphql.annotation.Directive;
+import graphql.schema.idl.SchemaDirectiveWiring;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.beans.factory.BeanInitializationException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link DirectivePostProcessor}.
+ *
+ * @author yuheng.wang
+ */
+public class DirectivePostProcessorTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private final DirectivePostProcessor directivePostProcessor = new DirectivePostProcessor();
+
+    @Test
+    public void should_throw_exception_if_directive_class_not_a_wiring() {
+        thrown.expect(BeanInitializationException.class);
+        thrown.expectMessage("directive bean must implements SchemaDirectiveWiring! bean:a");
+        directivePostProcessor.postProcessBeforeInitialization(new IllegalDirective(), "a");
+    }
+
+    @Test
+    public void should_throw_exception_if_directive_class_not_a_wiring1() {
+        directivePostProcessor.postProcessBeforeInitialization(new CorrectDirective(), "a");
+        Map<String, SchemaDirectiveWiring> map = (Map<String, SchemaDirectiveWiring>) ReflectionTestUtils.getField(RuntimeWiringRegistry.class, "NAME_AND_DIRECTIVE_WIRING");
+        assertNotNull(map);
+        assertEquals(1, map.size());
+        assertTrue(map.containsKey("b"));
+    }
+
+    @Directive
+    static class IllegalDirective {
+
+    }
+
+    @Directive("b")
+    static class CorrectDirective implements SchemaDirectiveWiring {
+
+    }
+
+}

--- a/sample/graphql-sample/src/main/java/com/github/yituhealthcare/arcgraphqlsample/biz/AuthService.java
+++ b/sample/graphql-sample/src/main/java/com/github/yituhealthcare/arcgraphqlsample/biz/AuthService.java
@@ -1,0 +1,23 @@
+package com.github.yituhealthcare.arcgraphqlsample.biz;
+
+import org.springframework.expression.AccessException;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author wangyuheng
+ */
+@Service
+public class AuthService {
+
+    public void valid(String targetAuthRole, String authorization) throws AccessException {
+        String role = resolveRoleByToken(authorization);
+        if (!targetAuthRole.equalsIgnoreCase(role)) {
+            throw new AccessException("auth fail!");
+        }
+    }
+
+    private String resolveRoleByToken(String token) {
+        return token;
+    }
+
+}

--- a/sample/graphql-sample/src/main/java/com/github/yituhealthcare/arcgraphqlsample/directive/AuthDirective.java
+++ b/sample/graphql-sample/src/main/java/com/github/yituhealthcare/arcgraphqlsample/directive/AuthDirective.java
@@ -1,0 +1,48 @@
+package com.github.yituhealthcare.arcgraphqlsample.directive;
+
+import com.github.yituhealthcare.arc.graphql.annotation.Directive;
+import graphql.GraphQLContext;
+import graphql.schema.DataFetcher;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLFieldsContainer;
+import graphql.schema.idl.SchemaDirectiveWiring;
+import graphql.schema.idl.SchemaDirectiveWiringEnvironment;
+import org.springframework.expression.AccessException;
+
+import java.util.Map;
+
+/**
+ * @author wangyuheng
+ */
+@Directive("Auth")
+public class AuthDirective implements SchemaDirectiveWiring {
+
+    @Override
+    public GraphQLFieldDefinition onField(SchemaDirectiveWiringEnvironment<GraphQLFieldDefinition> environment) {
+        String targetAuthRole = (String) environment.getDirective().getArgument("role").getValue();
+
+        GraphQLFieldDefinition field = environment.getElement();
+        GraphQLFieldsContainer parentType = environment.getFieldsContainer();
+        // build a data fetcher that first checks authorisation roles before then calling the original data fetcher
+        DataFetcher originalDataFetcher = environment.getCodeRegistry().getDataFetcher(parentType, field);
+        DataFetcher authDataFetcher = dataFetchingEnvironment -> {
+            GraphQLContext graphQLContext = dataFetchingEnvironment.getContext();
+            Map<String, Object> headers = graphQLContext.get("headers");
+            String authorization = String.valueOf(headers.getOrDefault("authorization", ""));
+            String role = resolveRoleByToken(authorization);
+            if (targetAuthRole.equalsIgnoreCase(role)) {
+                return originalDataFetcher.get(dataFetchingEnvironment);
+            } else {
+                throw new AccessException("auth fail!");
+            }
+        };
+        // now change the field definition to have the new authorising data fetcher
+        environment.getCodeRegistry().dataFetcher(parentType, field, authDataFetcher);
+        return field;
+    }
+
+    private String resolveRoleByToken(String token) {
+        return token;
+    }
+
+}

--- a/sample/graphql-sample/src/main/resources/config/application-graphql.playground.yml
+++ b/sample/graphql-sample/src/main/resources/config/application-graphql.playground.yml
@@ -1,6 +1,5 @@
 graphql.playground:
   mapping: /playground
-  endpoint: /schema
   enabled: true
   pageTitle: GraphqlExample
   cdn:

--- a/sample/graphql-sample/src/main/resources/config/application-graphql.playground.yml
+++ b/sample/graphql-sample/src/main/resources/config/application-graphql.playground.yml
@@ -20,7 +20,7 @@ graphql.playground:
     schema.disableComments: false
     tracing.hideTracingResponse: true
   headers:
-    Authorization: bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2luZm8iOiJ7XCJlbWFpbFwiOlwiMTIzQDEyMy5jb21cIixcImlkXCI6MTAwMDAwNjksXCJwaG9uZVwiOlwiMTIzMTIzMTIzXCIsXCJyb2xlXCI6MSxcInRydWVOYW1lXCI6XCJhcGlcIixcInVzZXJuYW1lXCI6XCJhcGlcIn0iLCJpc3MiOiJLQUtBUE8iLCJleHAiOjE2NTI1MTE4OTZ9.uPA2nVPEJCVk6NvEurczy1hB8TeF9pjf5Qn_6-w9Feo
+    Authorization: admin
     Namespace: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lc3BhY2UiOiIweDIifQ.uM_gyrCmoqyS81rJtgzxrl_gqZumgXK4lvmwmJSH3mk
   tabs:
     - name: projectQuery

--- a/sample/graphql-sample/src/main/resources/config/application-graphql.voyager.yml
+++ b/sample/graphql-sample/src/main/resources/config/application-graphql.voyager.yml
@@ -1,6 +1,5 @@
 voyager:
   enabled: true
   mapping: /voyager
-  endpoint: /schema
   cdn:
     enabled: false

--- a/sample/graphql-sample/src/main/resources/graphql/schema.graphqls
+++ b/sample/graphql-sample/src/main/resources/graphql/schema.graphqls
@@ -1,5 +1,6 @@
 scalar DateTime
 directive @Size(min : Int = 0, max : Int = 20, message : String = "graphql.validation.Size.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @Auth(role : String!) on FIELD_DEFINITION
 
 schema{
     query: Query,
@@ -18,7 +19,7 @@ type Query{
 type Mutation{
     createProject(
         payload: ProjectInput
-    ): Project
+    ): Project @Auth(role : "admin")
 }
 
 """


### PR DESCRIPTION
1. `graphqlContext` 增加 `http headers` 参数传递
2.  增加 **自定义 directive component** 注册的方式
3.  提供 **自定义 directive component** 的示例

close #68 